### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/.utm-lint.json
+++ b/.utm-lint.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["FiftyOne\\.GeoLocation[^/]*\\.xml$"]
+}

--- a/Examples/Cloud/AspNetCore/Startup.cs
+++ b/Examples/Cloud/AspNetCore/Startup.cs
@@ -86,7 +86,7 @@ namespace AspNetCore
                      resourceKey.ToString().StartsWith("!!")))
                 {
                     throw new Exception("You need to create a resource key at " +
-                        "https://configure.51degrees.com and paste it into the " +
+                        "https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-cloud-aspnetcore-startup.cs&utm_term=resource-key-required and paste it into the " +
                         "appsettings.json file in this example.");
                 }
             }

--- a/Examples/Cloud/AspNetCore/appsettings.json
+++ b/Examples/Cloud/AspNetCore/appsettings.json
@@ -13,7 +13,7 @@
         "BuilderName": "CloudRequestEngine",
         "BuildParameters": {
           // Obtain a resource key with the properties required to test this 
-          // example for free: https://configure.51degrees.com/v399y42f
+          // example for free: https://configure.51degrees.com/v399y42f?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-cloud-aspnetcore-appsettings.json&utm_term=buildparameters
           // The properties used in this example are:
           // Country, State, County, Town, JavaScript
           "ResourceKey": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!"

--- a/Examples/Cloud/GettingStarted/Program.cs
+++ b/Examples/Cloud/GettingStarted/Program.cs
@@ -40,7 +40,7 @@ using System.Threading.Tasks;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com).
+/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=location-dotnet&amp;utm_content=examples-cloud-gettingstarted-program.cs&amp;utm_term=gettingstarted).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.GeoLocation](https://www.nuget.org/packages/FiftyOne.GeoLocation/)
@@ -71,7 +71,7 @@ namespace GettingStarted
             {
                 // Create a new pipeline builder.
                 var pipelineBuilder = new GeoLocationPipelineBuilder(_loggerFactory)
-                    // Obtain a resource key from https://configure.51degrees.com 
+                    // Obtain a resource key from https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-cloud-gettingstarted-program.cs&utm_term=run 
                     // and select your Geo Location provider.
                     .UseCloud(resourceKey, FiftyOne.GeoLocation.Core.GeoLocationProvider.FiftyOneDegrees)
                     .UseLazyLoading(TimeSpan.FromSeconds(10));
@@ -124,14 +124,14 @@ namespace GettingStarted
 
         static void Main(string[] args)
         {
-            // Obtain a resource key for free at https://configure.51degrees.com
+            // Obtain a resource key for free at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-cloud-gettingstarted-program.cs&utm_term=main
             // Make sure to include the 'Country' property as it is used by this example.
             string resourceKey = args.Length > 0 ? args[0] : "!!YOUR_RESOURCE_KEY!!";
 
             if (resourceKey.StartsWith("!!"))
             {
                 Console.WriteLine("You need to create a resource key at " +
-                    "https://configure.51degrees.com and paste it into this example.");
+                    "https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-cloud-gettingstarted-program.cs&utm_term=resource-key-required and paste it into this example.");
                 Console.WriteLine("Make sure to include the 'Country' " +
                     "property as it is used by this example.");
             }

--- a/Examples/CombiningServices/Program.cs
+++ b/Examples/CombiningServices/Program.cs
@@ -47,7 +47,7 @@ using System.Threading.Tasks;
 /// properties you are interested in as well as any associated license keys 
 /// that entitle you to increased request limits and/or paid-for properties.
 /// 
-/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com).
+/// You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com?utm_source=code&amp;utm_medium=example&amp;utm_campaign=location-dotnet&amp;utm_content=examples-combiningservices-program.cs&amp;utm_term=combiningservices).
 /// 
 /// Required NuGet Dependencies:
 /// - [FiftyOne.GeoLocation](https://www.nuget.org/packages/FiftyOne.GeoLocation/)
@@ -164,7 +164,7 @@ namespace CombiningServices
 
         static void Main(string[] args)
         {
-            // Obtain a resource key for free at https://configure.51degrees.com
+            // Obtain a resource key for free at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-combiningservices-program.cs&utm_term=main
             // Make sure to include the 'Country' and 'IsMobile' properties as
             // they are used by this example.
             string resourceKey = args.Length > 0 ? args[0] : "!!YOUR_RESOURCE_KEY!!";
@@ -172,7 +172,7 @@ namespace CombiningServices
             if (resourceKey.StartsWith("!!"))
             {
                 Console.WriteLine("You need to create a resource key at " +
-                    "https://configure.51degrees.com and paste it into this example.");
+                    "https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-dotnet&utm_content=examples-combiningservices-program.cs&utm_term=resource-key-required and paste it into this example.");
                 Console.WriteLine("Make sure to include the 'Country' and " +
                     "'IsMobile' properties as they are used by this example.");
             }

--- a/FiftyOne.GeoLocation.Cloud/FiftyOne.GeoLocation.Cloud.csproj
+++ b/FiftyOne.GeoLocation.Cloud/FiftyOne.GeoLocation.Cloud.csproj
@@ -21,7 +21,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees;location;geolocation;longitude;latitude,cloud</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/location-dotnet</RepositoryUrl>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=location-dotnet&amp;utm_content=fiftyone.geolocation.cloud-fiftyone.geolocation.cloud.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageIcon>51d-logo.png</PackageIcon>

--- a/FiftyOne.GeoLocation.Core/FiftyOne.GeoLocation.Core.csproj
+++ b/FiftyOne.GeoLocation.Core/FiftyOne.GeoLocation.Core.csproj
@@ -19,7 +19,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees;location;geolocation;longitude;latitude</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/location-dotnet</RepositoryUrl>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=location-dotnet&amp;utm_content=fiftyone.geolocation.core-fiftyone.geolocation.core.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
 	  <PackageIcon>51d-logo.png</PackageIcon>

--- a/FiftyOne.GeoLocation/FiftyOne.GeoLocation.csproj
+++ b/FiftyOne.GeoLocation/FiftyOne.GeoLocation.csproj
@@ -20,7 +20,7 @@
 	  <PackageTags>51degrees;location;geolocation;longitude;latitude</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/location-dotnet</RepositoryUrl>
 	  <PackageIcon>51d-logo.png</PackageIcon>
-	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com?utm_source=nuget&amp;utm_medium=package&amp;utm_campaign=location-dotnet&amp;utm_content=fiftyone.geolocation-fiftyone.geolocation.csproj&amp;utm_term=packageprojecturl</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/FiftyOne.GeoLocation/GeoLocationPipelineBuilder.cs
+++ b/FiftyOne.GeoLocation/GeoLocationPipelineBuilder.cs
@@ -82,7 +82,7 @@ namespace FiftyOne.GeoLocation
         /// </summary>
         /// <param name="resourceKey">
         /// The resource key to use when querying the cloud service. 
-        /// Obtain one from https://configure.51degrees.com
+        /// Obtain one from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=location-dotnet&amp;utm_content=fiftyone.geolocation-geolocationpipelinebuilder.cs&amp;utm_term=usecloud
         /// </param>
         /// <param name="provider">
         /// The Geo Location provider to use.
@@ -102,7 +102,7 @@ namespace FiftyOne.GeoLocation
         /// </summary>
         /// <param name="resourceKey">
         /// The resource key to use when querying the cloud service. 
-        /// Obtain one from https://configure.51degrees.com
+        /// Obtain one from https://configure.51degrees.com?utm_source=code&amp;utm_medium=comment&amp;utm_campaign=location-dotnet&amp;utm_content=fiftyone.geolocation-geolocationpipelinebuilder.cs&amp;utm_term=usecloud-2
         /// </param>
         /// <param name="endpoint">
         /// The 51Degrees cloud URL.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![51Degrees](https://raw.githubusercontent.com/51Degrees/common-ci/main/images/logo/360x67.png "Data rewards the curious") **Pipeline API**
 
-[Developer Documentation](https://51degrees.com/location-dotnet/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=dotnet-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/location-dotnet/index.html?utm_source=github&utm_medium=readme&utm_campaign=location-dotnet&utm_content=readme.md&utm_term=51degrees-geo-location-engines "developer documentation")
 ## Introduction
 
 This repository contains engines for the .NET implementation of the Pipeline API 
@@ -16,7 +16,7 @@ Visual Studio 2019 or later is recommended. Although Visual Studio Code can be u
 
 The Pipeline engines are written in C# and target .NET Standard 2.0.3.
 
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=location-dotnet&utm_content=readme.md&utm_term=dependencies) page shows 
 the .NET versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -53,6 +53,6 @@ with the `dotnet test` command.
 
 For complete documentation on the Pipeline API and associated engines, see the [51Degrees documentation site][Documentation].
 
-[Documentation]: https://51degrees.com/documentation/index.html
+[Documentation]: https://51degrees.com/documentation/index.html?utm_source=github&utm_medium=readme&utm_campaign=location-dotnet&utm_content=readme.md&utm_term=project-documentation
 [nuget]: https://www.nuget.org/packages/FiftyOne.GeoLocation/
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,7 +6,7 @@ The following secrets are required:
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
 
 The following secrets are requred to run cloud tests:
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=location-dotnet&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
 
 The following secrets are required for publishing releases (this should only be needed by 51Degrees):


### PR DESCRIPTION
## Summary

Every navigational 51degrees.com and configure.51degrees.com link in this repository now carries the standard UTM query string so the Content Team can trace Matomo campaign traffic to the exact repository, file, and location it came from:

`?utm_source=<github|code|nuget|npm|maven|packagist>&utm_medium=<readme|docs|example|comment|package>&utm_campaign=<repository>&utm_content=<file slug>&utm_term=<location in file>`

17 links across 12 files, in-place URL replacements only, re-applied against the current README. The pre-2026 utm scheme was replaced and functional endpoints, test fixtures, license headers, and generated files are untouched.

## Lint

A second commit adds the utm-link-lint workflow, which runs the shared script from 51Degrees/common-ci on pull requests and pushes to main, keeping the convention enforced from now on. An accompanying .utm-lint.json excludes the committed compiler-generated documentation XML, which picks the tagged URLs up at the next build. The lint check on this PR stays red until 51Degrees/common-ci#207 merges, since the workflow fetches the script from that repository's main.

The full convention is documented in UTM-LINK-TAGGING.md in 51Degrees/internal-common-ci (PR 3).